### PR TITLE
Update AirTag-create.sh

### DIFF
--- a/AirTag-create.sh
+++ b/AirTag-create.sh
@@ -48,7 +48,7 @@ if [[ $beacon == "u" ]]; then
     # AirTag payload 1eff4c001219006725acc77b7e7a5cb8b8050519a2f6748a5ac7a00b890100
     echo "Sending an unregistered AirTag beacon:"
     sudo hcitool -i hci0 cmd 0x03 0x0003 #HCI reset
-    sudo hcitool -i hci0 cmd 0x08 0x0008 1f 1e ff 4c 00 12 19 00 67 25 ac c7 7b 7e 7a 5c b8 b8 05 05 19 a2 f6 74 8a 5a c7 a0 0b 89 01 00
+    sudo hcitool -i hci0 cmd 0x08 0x0008 1f 1e ff 4c 00 07 19 00 67 25 ac c7 7b 7e 7a 5c b8 b8 05 05 19 a2 f6 74 8a 5a c7 a0 0b 89 01 00
     sudo hcitool -i hci0 cmd 0x08 0x0006 d0 07 d0 07 03 00 00 00 00 00 00 00 00 07 00
     sudo hcitool -i hci0 cmd 0x08 0x000a 01
 fi
@@ -60,7 +60,7 @@ if [[ $beacon == "r" ]]; then
     # AirTag payload 1eff4c000719006725acc77b7e7a5cb8b8050519a2f6748a5ac7a00b890100
     echo "Sending a registered AirTag beacon:"
     sudo hcitool -i hci0 cmd 0x03 0x0003 # HCI reset
-    sudo hcitool -i hci0 cmd 0x08 0x0008 1f 1e ff 4c 00 07 19 00 67 25 ac c7 7b 7e 7a 5c b8 b8 05 05 19 a2 f6 74 8a 5a c7 a0 0b 89 01 00
+    sudo hcitool -i hci0 cmd 0x08 0x0008 1f 1e ff 4c 00 12 19 00 67 25 ac c7 7b 7e 7a 5c b8 b8 05 05 19 a2 f6 74 8a 5a c7 a0 0b 89 01 00
     sudo hcitool -i hci0 cmd 0x08 0x0006 d0 07 d0 07 03 00 00 00 00 00 00 00 00 07 00
     sudo hcitool -i hci0 cmd 0x08 0x000a 01
 fi


### PR DESCRIPTION
the unregistered vs registered byte for advertising were reversed, now fixed - 0x12 for registered and 0x07 for unregistered as it should be.